### PR TITLE
Add `gh_environment` line to workflows

### DIFF
--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -25,6 +25,7 @@ jobs:
     with:
       app_name: fdk-harvest-admin
       environment: prod
+      gh_environment: prod
       build_env: true
       build_env_name: BINARY
       build_env_value: fdk-harvest-admin
@@ -38,6 +39,7 @@ jobs:
     with:
       app_name: fdk-harvest-admin
       environment: prod
+      gh_environment: prod
       cluster: digdir-fdk-prod
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,6 +53,7 @@ jobs:
     with:
       app_name: fdk-harvest-admin
       environment: demo
+      gh_environment: demo
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -26,6 +26,7 @@ jobs:
     with:
       app_name: fdk-harvest-admin
       environment: staging
+      gh_environment: staging
       build_env: true
       build_env_name: BINARY
       build_env_value: fdk-harvest-admin
@@ -40,6 +41,7 @@ jobs:
     with:
       app_name: fdk-harvest-admin
       environment: staging
+      gh_environment: staging
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds `gh_environment: <env>` after each `environment: <env>` line in key workflows.